### PR TITLE
Use shorter name for Czech republic

### DIFF
--- a/mapnik/lowlevel_shapefile/countries.osm
+++ b/mapnik/lowlevel_shapefile/countries.osm
@@ -884,7 +884,7 @@
     <nd ref='-5560' />
     <nd ref='-273' />
     <tag k='size' v='2' />
-    <tag k='text' v='Česká republika' />
+    <tag k='text' v='Česko' />
     <tag k='text_path' v='country' />
   </way>
 </osm>


### PR DESCRIPTION
All other countries are rendered with short name, so should be Czech
republic (though it is not yet that widely used name).
